### PR TITLE
Environment Aware Codegen

### DIFF
--- a/src/driver.ml
+++ b/src/driver.ml
@@ -45,17 +45,14 @@ var print_bool = print_me;
 var print = print_me;
 // generated code follows
 %s" in
-(*
   let stdlib = [("List", "lib/list.jsjs"); ("Map", "lib/map.jsjs")] in
   let module_names = String.concat ~sep:"" (List.map
       ~f: (fun (x, _) -> Printf.sprintf "let %s = {};" x) stdlib)
   in
   let js_of_stdlib = List.fold_left ~init: "" stdlib
       ~f: (fun acc (name, path) -> acc ^ (generate_stdlib path name)) in
-*)
   let outc = Out_channel.create filename in
-  Printf.fprintf outc template "" "" "" str;
-  (* Printf.fprintf outc template Lib.immutable module_names js_of_stdlib str;*)
+  Printf.fprintf outc template Lib.immutable module_names js_of_stdlib str;
   Out_channel.close outc
 ;;
 

--- a/test/compiler-tests/pass-fn_compose.jsjs
+++ b/test/compiler-tests/pass-fn_compose.jsjs
@@ -6,5 +6,5 @@ val not = /\(x: bool): bool => !x;
 // composing two functions
 val odd? = compose(not, even?);
 
-//val results = List.filter(odd?, List.range(1, 10));
-//List.iter(/\(x) => print_num(x), results);
+val results = List.filter(odd?, List.range(1, 10));
+List.iter(/\(x) => print_num(x), results);


### PR DESCRIPTION
Almost completely rewrote codegen. It now generates code using a little more scope information, as opposed to the word for word translation we were doing initially.

Did this because of Javascript's [funny behavior with 'let' and 'var' scoping](http://stackoverflow.com/questions/762011/let-keyword-vs-var-keyword). New codegen enforces more traditional scoping and shadowing rules in local and global scopes.

Fixes #72 
